### PR TITLE
Simulated Single Hop Communications

### DIFF
--- a/src/sim/controller/KillableThreadClass.py
+++ b/src/sim/controller/KillableThreadClass.py
@@ -2,8 +2,8 @@ import threading
 import ctypes
 
 class KillableThread(threading.Thread):
-    def __init__(self, target, args, name=""):
-        threading.Thread.__init__(self)
+    def __init__(self, target, args, daemon=False, name=""):
+        threading.Thread.__init__(self, daemon=daemon, name=name)
         self.__target = target
         self.__args = args
         self.__name = name

--- a/src/sim/controller/classes/vRouter.py
+++ b/src/sim/controller/classes/vRouter.py
@@ -1,0 +1,28 @@
+
+#### Router Class ####
+
+# Routing Table (Very Rudementary) Format:
+# dictionary = {
+#     "10.0.0.10": [("10.0.0.11", 1), ("10.0.0.12", 2)],
+#     "sourceIP": [("destIP", numHops), ...]
+# }
+
+class vRouter():
+    def __init__(self):
+        self.__table = dict()
+
+    # Efficiently update the key-value pair
+    def updateRoute(self, sourceIP, routeArray):
+        self.__table.update({sourceIP, routeArray})
+
+    # Inefficiently search the table for the best route
+    def findRoute(self, destIP):
+        bestRoute = (None, 65535)
+        
+        for key in self.__table.keys():
+            possibleRoutes = self.__table.get(key)
+            for tuple in possibleRoutes:
+                if (tuple[0] == destIP and tuple[1] < bestRoute[1]):
+                    bestRoute = tuple
+
+        return bestRoute[0]

--- a/src/sim/controller/classes/vRouter.py
+++ b/src/sim/controller/classes/vRouter.py
@@ -13,7 +13,7 @@ class vRouter():
 
     # Efficiently update the key-value pair
     def updateRoute(self, sourceIP, routeArray):
-        self.__table.update({sourceIP, routeArray})
+        self.__table.update({sourceIP: routeArray})
 
     # Inefficiently search the table for the best route
     def findRoute(self, destIP):
@@ -21,8 +21,13 @@ class vRouter():
         
         for key in self.__table.keys():
             possibleRoutes = self.__table.get(key)
+            
             for tuple in possibleRoutes:
                 if (tuple[0] == destIP and tuple[1] < bestRoute[1]):
                     bestRoute = tuple
+
+                    # Stop if route length is 1
+                    if (bestRoute[1] == 1):
+                        return bestRoute[0]
 
         return bestRoute[0]

--- a/src/sim/controller/classes/vRouter.py
+++ b/src/sim/controller/classes/vRouter.py
@@ -23,8 +23,8 @@ class vRouter():
             possibleRoutes = self.__table.get(key)
             
             for tuple in possibleRoutes:
-                if (tuple[0] == destIP and tuple[1] < bestRoute[1]):
-                    bestRoute = tuple
+                if (tuple[0] == destIP and int(tuple[1]) < int(bestRoute[1])):
+                    bestRoute = (key, tuple[1])
 
                     # Stop if route length is 1
                     if (bestRoute[1] == 1):

--- a/src/sim/controller/config/v_global_vars.py
+++ b/src/sim/controller/config/v_global_vars.py
@@ -2,6 +2,7 @@ import threading
 import queue
 import sim.sim_global_vars as sg
 from sim.controller.classes.vSerial import vSerial
+from sim.controller.classes.vRouter import vRouter
 
 '''
 Contains virtual global variables that will be used across sim files
@@ -58,3 +59,5 @@ class vGlobals():
         self.socketQueues = [queue.Queue() for _ in range(len(self.POSSIBLE_ROBOT_IP_ADDRESSES))]
 
         self.virtual_serial_port = vSerial(self)
+
+        self.router = vRouter()

--- a/src/sim/controller/threads/v_link_receive.py
+++ b/src/sim/controller/threads/v_link_receive.py
@@ -42,13 +42,17 @@ def v_link_receive(robot, vg):
                     routingInfo = checkForRouting[1][2:-2].translate(str.maketrans('', '', '(),')).replace("'","").split(" ")
                     # print(routingInfo)
                     formatRoutingInfo = list()
-                    
+
                     for i in range(0, len(routingInfo) - 1, 2):
                         formatRoutingInfo.append((routingInfo[i], routingInfo[i + 1]))
                         
-                    print(formatRoutingInfo)
+                    # print(formatRoutingInfo)
                     vg.router.updateRoute(robot.IP, formatRoutingInfo)
 
+                # Checking if the received packet is supposed to be forwarded
+                elif (vg.ip != data.split("\x00")[1].replace(" ","")):
+                    # Forward the data
+                    print(f"{vg.ip} forwarding {data}")
 
                 if(data == b''):
                     # Determine if the socket is in use by another robot

--- a/src/sim/controller/threads/v_link_receive.py
+++ b/src/sim/controller/threads/v_link_receive.py
@@ -50,9 +50,27 @@ def v_link_receive(robot, vg):
                     vg.router.updateRoute(robot.IP, formatRoutingInfo)
 
                 # Checking if the received packet is supposed to be forwarded
-                elif (vg.ip != data.split("\x00")[1].replace(" ","")):
+                elif (data.split("\x00")[3].replace(" ", "") == "\x02"):
+                    # Store the data portion of the packet
+                    newData = data.split("\x00")[5].replace(" ", "") 
+
+                    # Store the IP the data came from
+                    fromIP = data.split("\x00")[2].replace(" ", "")
+
+                    # Store the IP to forward to 
+                    forwardToIP = data.split("\x00")[4].replace(" ", "")
+
+                    # Find the matching socket
+                    forwardToRobot = None
+                    for r in vg.visible:
+                        if r.IP == forwardToIP:
+                            forwardToRobot = r
+                            break
+
                     # Forward the data
-                    print(f"{vg.ip} forwarding {data}")
+                    if forwardToRobot is not None:
+                        # Reformat packet and push to socket
+                        forwardToRobot.robotLink.socket.sendall("\x00" + str(forwardToRobot.IP) + "\x00 " + vg.ip + "\x00 " + f"->{fromIP}: {newData}")
 
                 if(data == b''):
                     # Determine if the socket is in use by another robot

--- a/src/sim/controller/threads/v_link_receive.py
+++ b/src/sim/controller/threads/v_link_receive.py
@@ -32,6 +32,24 @@ def v_link_receive(robot, vg):
                 # Update last packet time
                 robot.robotLink.lastPacketTime = time.time()
 
+
+                # Prototyping multi-hop communications code
+                # Receiving the routing info from other robot
+                checkForRouting = data.split('\x11')
+
+                if (len(checkForRouting) == 2):
+                    # Parse routing info from packet
+                    routingInfo = checkForRouting[1][2:-2].translate(str.maketrans('', '', '(),')).replace("'","").split(" ")
+                    # print(routingInfo)
+                    formatRoutingInfo = list()
+                    
+                    for i in range(0, len(routingInfo) - 1, 2):
+                        formatRoutingInfo.append((routingInfo[i], routingInfo[i + 1]))
+                        
+                    print(formatRoutingInfo)
+                    vg.router.updateRoute(robot.IP, formatRoutingInfo)
+
+
                 if(data == b''):
                     # Determine if the socket is in use by another robot
                     # This happens if the robot was deleted and a new one placed in its stead with same socket

--- a/src/sim/controller/threads/v_link_send.py
+++ b/src/sim/controller/threads/v_link_send.py
@@ -1,6 +1,5 @@
 import time
 import threading
-# import random
 import sim.sim_global_vars as sg
 
 def v_link_send(robot, vg):
@@ -15,6 +14,15 @@ def v_link_send(robot, vg):
             if vg.debug_link_send: print(f'{thread_name} Sending Payload through TCP Socket {payload}{send_num}')
             # packet = \x00 + IP_to + \x00 + IP_from + \x00 + Payload + Payload_Number
             robot.robotLink.socket.sendall("\x00" + str(robot.IP) + "\x00 " + vg.ip + "\x00 " + str(payload + send_num.to_bytes(4, byteorder="little")))
+
+            # Prototyping sending routing info (1 extra hop only)
+            if (send_num % 5 == 0):
+                robots = list()
+                
+                for r in vg.visible:
+                    robots.append((r.IP, 1))
+
+                robot.robotLink.socket.sendall("\x00" + str(robot.IP) + "\x00 " + vg.ip + "\x00 " + "\x11 " + str(robots))              
 
             send_num += 1
 

--- a/src/sim/controller/threads/v_link_send.py
+++ b/src/sim/controller/threads/v_link_send.py
@@ -22,8 +22,8 @@ def v_link_send(robot, vg):
                 for r in vg.visible:
                     robots.append((r.IP, 1))
 
-                robot.robotLink.socket.sendall("\x00" + str(robot.IP) + "\x00 " + vg.ip + "\x00 " + "\x11 " + str(robots))              
-
+                robot.robotLink.socket.sendall("\x00" + str(robot.IP) + "\x00 " + vg.ip + "\x00 " + "\x11 " + str(robots))
+                
             send_num += 1
 
         # Terminate if Robot no longer exists

--- a/src/sim/controller/threads/v_send_manager.py
+++ b/src/sim/controller/threads/v_send_manager.py
@@ -28,13 +28,28 @@ def v_send_manager(vg):
         # The following is not implemented in simulated packets:
         # packet_summary = analyze_packet(packet)
 
-        if vg.debug_send_manager: print(f'{thread_name} Forwarding packet through dataQ {packet}')
+        if vg.debug_send_manager: print(f'{thread_name} Sending packet through dataQ {packet}')
         
         # Sending data is simplified in the simulator because transceivers are not implemented
         # Additionally, all packets are of the same type
+        sendingTo = packet.split("\x00")[1]
 
+        # Protyping the Mulihop Communications
+        for robot in vg.visible:
+            if (robot.IP == sendingTo):
+                break
+        else:
+            old = sendingTo
+
+            # Update sendingTo to the IP of the shortest hop
+            sendingTo = vg.router.findRoute(sendingTo)
+
+            # Check to make sure a route is avaialble before trying to send
+            if (sendingTo is None):
+                print(f"{vg.ip} failed to send multi-hop packet to {old}. No route available.")
+                continue
+        
         # Simulate the sending of data (queue it for the receiving robot)
         # Access receiving robots dataQ
         # Send data with tag
-        sendingTo = packet.split("\x00")
-        sg.listOfDataQ[int(sendingTo[1].split(".")[-1])-10].put(packet + " ", timeout=3)
+        sg.listOfDataQ[int(sendingTo.split(".")[-1])-10].put(packet + " ", timeout=3)

--- a/src/sim/controller/threads/v_test_single_hop.py
+++ b/src/sim/controller/threads/v_test_single_hop.py
@@ -1,0 +1,46 @@
+import time
+import threading
+import sim.sim_global_vars as sg
+
+
+def v_test_single_hop(vg):
+    thread_name = threading.current_thread().name
+    payload = b'hello'
+    send_num = 0
+
+    while True:
+        # We will target sending single hop data only to ...10
+        ipForSingleHop = vg.router.findRoute("10.0.0.10")
+
+        if ipForSingleHop == None:
+            # Sleep the Link Send Thread
+            # print(f"{vg.ip} none")
+            time.sleep(vg.PAYLOAD_INTERVAL_SLEEP)
+            continue
+
+        # Find robot with ip matching the best route
+        robot = None
+        
+        with vg.visible_mutex:
+            for r in vg.visible:
+                if r.IP == ipForSingleHop:
+                    robot = r
+                    # print(f"{vg.ip} found robot with ip {r.IP}")
+
+        if robot is None:
+            # Sleep the Link Send Thread
+            time.sleep(vg.PAYLOAD_INTERVAL_SLEEP)
+            continue
+
+        if robot.robotLink is not None:
+            # print(f"{vg.ip} sending to robot with ip {robot.IP}")
+            # Send Payload through Socket 
+            if vg.debug_link_send: print(f'{thread_name} Sending Payload through TCP Socket {payload}{send_num}')
+            # packet = \x00 + IP_to + \x00 + IP_from + \x00 + Payload + Payload_Number
+            # robot.robotLink.socket.sendall("\x00" + str(robot.IP) + "\x00 " + vg.ip + "\x00 " + str(payload + send_num.to_bytes(4, byteorder="little")))
+            # packet = \x00 + IP_to + \x00 + IP_from + \x00 + \x02 + \x00 + IP_forward + \x00 + Payload + Payload_Number
+            # forward_flag = \x02
+            robot.robotLink.socket.sendall("\x00" + str(robot.IP) + "\x00 " + vg.ip + "\x00 " + "\x02 " + "\x00 " + "10.0.0.10" + "\x00 " + str(payload + send_num.to_bytes(4, byteorder="little")))
+
+        # Sleep the Link Send Thread
+        time.sleep(vg.PAYLOAD_INTERVAL_SLEEP)

--- a/src/sim/controller/v_main.py
+++ b/src/sim/controller/v_main.py
@@ -1,5 +1,6 @@
 import threading
 import queue
+from sim.controller.KillableThreadClass import KillableThread
 from sim.controller.config.v_global_vars import vGlobals
 from sim.controller.classes.vDetectorClass import vDetector
 from sim.controller.threads.v_new_visible import v_new_visible
@@ -8,6 +9,7 @@ from sim.controller.threads.v_link_receive import v_link_receive
 from sim.controller.threads.v_link_send import v_link_send
 from sim.controller.threads.v_send_manager import v_send_manager
 from sim.controller.threads.v_receive_manager import v_receive_manager
+from sim.controller.threads.v_test_single_hop import v_test_single_hop
 
 def v_main(params):
     robotModel = params[0]
@@ -40,6 +42,10 @@ def v_main(params):
 
     # Store Thread Number
     thread_number = 0
+
+    # Add in quick test
+    test_single_hop_thread = threading.Thread(target=v_test_single_hop, args=[vg], daemon=True, name=f"Test_Single_Hop")
+    if vg.ip == "10.0.0.12": test_single_hop_thread.start()
 
     while robotModel.robotItem.isActive():
         # Blocking Call to Get New Robot


### PR DESCRIPTION
### Simulated Single Hop Communications
For ease of debugging, the test hop thread is only for 10.0.0.12 sending 10.0.0.10. This can easily be expanding for all robots looking to send to all others

**Additions:**
- Added vRouter(), a class that stores a routing table, can easily be updated, and can be searched for routes
- Added forwarding of single hop information as a special data packet after every 5 transmissions
- Read/parse single hop information to create routing table
- Get new routing information
- Forwarding data received with a forward flag
- Added v_test_single_hop thread to demonstrate single hop comms